### PR TITLE
Building a Minimal Viable Armv7 Emulator

### DIFF
--- a/content/posts/2025/building-a-minimal-viable-armv7-emulator.md
+++ b/content/posts/2025/building-a-minimal-viable-armv7-emulator.md
@@ -1394,11 +1394,11 @@ says:
 > instruction will be generated.
 
 Now this may not make sense at a first glance, why would `=msg` be assembled
-into an address to the address of the literal. But an `armv7` can not encode a
-full address, it is impossible due to the instruction being restricted to an
-8-bit value rotated right by an even number of bits. The ldr instructions
-argument points to a literal pool entry. The LDR instruction reads a 32-bit
-value at the literal pool entry and this value is the actual address of msg.
+into an address to the address of the literal. But an `armv7` instruction can
+not encode a full address, it is impossible due to the instruction being
+restricted to an 8-bit value rotated right by an even number of bits. The ldr
+instructions argument points to a literal pool entry, this entry is a 32-bit
+value and reading it produces the actual address of `msg`.
 
 When decoding we can see ldr points to a memory address (32800 or `0x8020`) in
 the section we mmaped earlier:
@@ -1732,6 +1732,15 @@ pub fn syscall_forward(cpu: &mut super::Cpu, syscall: ArmSyscall) -> i32 {
         // ...
     }
 }
+```
+
+Executing `helloWorld.elf` now results in:
+
+```shell
+$ stinkarm -Cforward example/helloWorld.elf
+Hello, world!
+$ echo $status
+0
 ```
 
 ### Deny and Sandbox - restricting syscalls

--- a/content/posts/2025/building-a-minimal-viable-armv7-emulator.md
+++ b/content/posts/2025/building-a-minimal-viable-armv7-emulator.md
@@ -2,7 +2,6 @@
 title: "Building a Minimal Viable Armv7 Emulator from Scratch"
 date: 2025-11-19
 summary: "Emulating armv7 is surprisingly easy, even from scratch AND in Rust"
-draft: true
 tags:
   - arm
   - rust

--- a/content/posts/2025/building-a-minimal-viable-armv7-emulator.md
+++ b/content/posts/2025/building-a-minimal-viable-armv7-emulator.md
@@ -9,11 +9,13 @@ tags:
 ---
 
 After reading about the process the Linux kernel performs to execute binaries,
-I thought: I want to write an armv7 emulator - `stinkarm`. Understand the ELF
+I thought: I want to write an armv7 emulator -
+[`stinkarm`](https://github.com/xnacly/stinkarm). Mosty to understand the ELF
 format, the encoding of arm 32bit instructions, the execution of arm assembly
 and how it all fits together (this will help me with the JIT for my programming
-language I am currently designing). Thus, no dependencies. And of course Rust!
-I already have enough C projects right now.
+language I am currently designing). To fully understand everything: no
+dependencies. And of course Rust, since I already have enough C projects going
+on.
 
 So I wrote the smallest binary I could think of:
 
@@ -21,7 +23,7 @@ So I wrote the smallest binary I could think of:
     .global _start  @ declare _start as a global
 _start:             @ start is the defacto entry point
     mov r0, #161    @ first and only argument to the exit syscall
-    mov r7, #1      @ exit syscall (1)
+    mov r7, #1      @ syscall number 1 (exit)
     svc #0          @ trapping into the kernel (thats US, since we are translating)
 ```
 
@@ -30,8 +32,8 @@ To execute this arm assembly on my x86 system, I need to:
 1. Parse the ELF, validate it is armv7 and statically executable (I don't want
    to write a dynamic dependency resolver and loader)
 2. Map the segments defined in ELF into the host memory, forward memory access
-3. Emulate the CPU, its state and registers
-4. Decode armv7 instructions and convert them into a nice Rust enum
+3. Decode armv7 instructions and convert them into a nice Rust enum
+4. Emulate the CPU, its state and registers
 5. Execute the instructions and apply their effects to the CPU state
 6. Translate and forward syscalls
 
@@ -78,7 +80,7 @@ clean:
 }
 ```
 
-# Parsing ELF
+# Step 1: Parsing ELF
 
 So there are some resources for parsing ELF, two of them I used a whole lot:
 
@@ -98,14 +100,6 @@ of the header.
 
 In terms of byte layout:
 
-```shell
-$ xxd -g1 -l52 examples/asm.elf
-00000000: 7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00  .ELF............
-00000010: 02 00 28 00 01 00 00 00 00 80 00 00 34 00 00 00  ..(.........4...
-00000020: dc 11 00 00 00 02 00 05 34 00 20 00 01 00 28 00  ........4. ...(.
-00000030: 08 00 07 00                                      ....
-```
-
 | bytes  | structure  |
 | ------ | ---------- |
 | 0..16  | Identifier |
@@ -122,6 +116,14 @@ $ xxd -g1 -l52 examples/asm.elf
 | 46..48 | shentsize  |
 | 48..50 | shnum      |
 | 50..52 | shstrndx   |
+
+```shell
+$ xxd -g1 -l52 examples/asm.elf
+00000000: 7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00  .ELF............
+00000010: 02 00 28 00 01 00 00 00 00 80 00 00 34 00 00 00  ..(.........4...
+00000020: dc 11 00 00 00 02 00 05 34 00 20 00 01 00 28 00  ........4. ...(.
+00000030: 08 00 07 00                                      ....
+```
 
 ```rust
 /// Representing the ELF Object File Format header in memory, equivalent to Elf32_Ehdr in 2. ELF
@@ -393,7 +395,346 @@ macro_rules! le32 {
 
 ## Elf32_Phdr
 
+For me, the most important fields in `Header` are `phoff` and `phentsize`,
+since we can use these to index into the binary to locate the program headers.
+
+```rust
+/// Phdr, equivalent to Elf32_Phdr, see: https://gabi.xinuos.com/elf/07-pheader.html
+///
+/// All of its member are u32, be it Elf32_Word, Elf32_Off or Elf32_Addr
+#[derive(Debug)]
+pub struct Pheader {
+    pub r#type: Type,
+    /// offset to the segment, starting from file idx
+    pub offset: u32,
+    /// virtual address where the first byte of the segment lays
+    pub vaddr: u32,
+    /// On systems for which physical addressing is relevant, this member is reserved for the
+    /// segment’s physical address. Because System V ignores physical addressing for application
+    /// programs, this member has unspecified contents for executable files and shared objects.
+    pub paddr: u32,
+    /// This member gives the number of bytes in the file image of the segment; it may be zero.
+    pub filesz: u32,
+    /// This member gives the number of bytes in the memory image of the segment; it may be zero.
+    pub memsz: u32,
+    pub flags: Flags,
+    /// Loadable process segments must have congruent values for p_vaddr and p_offset, modulo the page
+    /// size. This member gives the value to which the segments are aligned in memory and in the
+    /// file. Values 0 and 1 mean no alignment is required. Otherwise, p_align should be a
+    /// positive, integral power of 2, and p_vaddr should equal p_offset, modulo p_align.
+    pub align: u32,
+}
+
+impl Pheader {
+    /// extracts Pheader from raw, starting from offset
+    pub fn from(raw: &[u8], offset: usize) -> Result<Self, String> {
+        let end = offset.checked_add(32).ok_or("Offset overflow")?;
+        if raw.len() < end {
+            return Err("Not enough bytes to parse Elf32_Phdr, need at least 32".into());
+        }
+
+        let p_raw = &raw[offset..end];
+        let r#type = p_raw[0..4].try_into()?;
+        let flags = p_raw[24..28].try_into()?;
+        let align = le32!(p_raw[28..32]);
+
+        if align > 1 && !align.is_power_of_two() {
+            return Err(format!("Invalid p_align: {}", align));
+        }
+
+        Ok(Self {
+            r#type,
+            offset: le32!(p_raw[4..8]),
+            vaddr: le32!(p_raw[8..12]),
+            paddr: le32!(p_raw[12..16]),
+            filesz: le32!(p_raw[16..20]),
+            memsz: le32!(p_raw[20..24]),
+            flags,
+            align,
+        })
+    }
+}
+```
+
+`Type` holds info about what type of segment the header defines:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum Type {
+    /// The array element is unused; other members’ values are undefined. This type lets the
+    /// program header table have ignored entries.
+    NULL = 0,
+    /// The array element specifies a loadable segment, described by p_filesz and p_memsz. The
+    /// bytes from the file are mapped to the beginning of the memory segment. If the segment’s
+    /// memory size (p_memsz) is larger than the file size (p_filesz), the “extra” bytes are
+    /// defined to hold the value 0 and to follow the segment’s initialized area. The file size may
+    /// not be larger than the memory size. Loadable segment entries in the program header table
+    /// appear in ascending order, sorted on the p_vaddr member.
+    LOAD = 1,
+    /// The array element specifies dynamic linking information. See Section 8.3, Dynamic Section,
+    /// for more information.
+    DYNAMIC = 2,
+    /// The array element specifies the location and size of a null-terminated path name to invoke
+    /// as an interpreter. This segment type is meaningful only for executable files (though it may
+    /// occur for shared objects); it may not occur more than once in a file. If it is present, it
+    /// must precede any loadable segment entry. See Section 8.1, Program Interpreter, for more
+    /// information.
+    INTERP = 3,
+    /// The array element specifies the location and size of auxiliary information. See Section
+    /// 7.6, Note Sections, for more information.
+    NOTE = 4,
+    /// This segment type is reserved but has unspecified semantics. Programs that contain an array
+    /// element of this type do not conform to the ABI.
+    SHLIB = 5,
+    /// The array element, if present, specifies the location and size of the program header table
+    /// itself, both in the file and in the memory image of the program. This segment type may not
+    /// occur more than once in a file. Moreover, it may occur only if the program header table is
+    /// part of the memory image of the program. If it is present, it must precede any loadable
+    /// segment entry.
+    PHDR = 6,
+    /// The array element specifies the Thread-Local Storage template. Implementations need not
+    /// support this program table entry. See Section 7.7, Thread-Local Storage, for more
+    /// information.
+    TLS = 7,
+    /// Values in this inclusive range are reserved for operating system-specific semantics.
+    LOOS = 0x60000000,
+    HIOS = 0x6fffffff,
+    /// Values in this inclusive range are reserved for processor-specific semantics. If meanings
+    /// are specified, the psABI supplement explains them.
+    LOPROC = 0x70000000,
+    HIPROC = 0x7fffffff,
+}
+
+impl TryFrom<&[u8]> for Type {
+    type Error = &'static str;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != 4 {
+            return Err("Elf32_Phdr.p_type requires exactly 4 bytes");
+        }
+
+        Ok(match le32!(value) {
+            0 => Self::NULL,
+            1 => Self::LOAD,
+            2 => Self::DYNAMIC,
+            3 => Self::INTERP,
+            4 => Self::NOTE,
+            5 => Self::SHLIB,
+            6 => Self::PHDR,
+            7 => Self::TLS,
+            _ => return Err("Bad Elf32_Phdr.p_type value"),
+        })
+    }
+}
+```
+
+`Flag` defines the
+permission flags the segment should have once it is dumped into memory:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+/// See 7.4. Segment Permission https://gabi.xinuos.com/elf/07-pheader.html#segment-permissions
+pub struct Flags(u32);
+
+impl Flags {
+    pub const NONE: Self = Flags(0x0);
+    pub const X: Self = Flags(0x1);
+    pub const W: Self = Flags(0x2);
+    pub const R: Self = Flags(0x4);
+
+    pub fn bits(self) -> u32 {
+        self.0
+    }
+}
+
+impl TryFrom<&[u8]> for Flags {
+    type Error = &'static str;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != 4 {
+            return Err("Not enough bytes for Elf32_Phdr.p_flags, need 4");
+        }
+
+        Ok(Self(le32!(value)))
+    }
+}
+
+impl std::ops::BitOr for Flags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Flags(self.0 | rhs.0)
+    }
+}
+```
+
+## Full ELF parsing 
+
+Putting `Elf32_Ehdr` and `Elf32_Phdr` parsing together:
+
+```rust
+/// Representing an ELF32 binary in memory
+///
+/// This does not include section headers (Elf32_Shdr), but only program headers (Elf32_Phdr), see either `man elf` and/or https://gabi.xinuos.com/elf/03-sheader.html
+#[derive(Debug)]
+pub struct Elf {
+    pub header: header::Header,
+    pub pheaders: Vec<pheader::Pheader>,
+}
+
+impl TryFrom<&[u8]> for Elf {
+    type Error = String;
+
+    fn try_from(b: &[u8]) -> Result<Self, String> {
+        let header = header::Header::try_from(b).map_err(|e| e.to_string())?;
+
+        let mut pheaders = Vec::with_capacity(header.phnum as usize);
+        for i in 0..header.phnum {
+            let offset = header.phoff as usize + i as usize * header.phentsize as usize;
+            let ph = pheader::Pheader::from(b, offset)?;
+            pheaders.push(ph);
+        }
+
+        Ok(Elf { header, pheaders })
+    }
+}
+```
+
+The equivalent to `readelf -l`:
+
+```text
+Elf { 
+    header: Header {
+        ident: Identifier {
+            magic: [127, 69, 76, 70],
+            class: 1,
+            data: 1,
+            version: 1,
+            os_abi: 0,
+            abi_version: 0,
+            _pad: [0, 0, 0, 0, 0, 0, 0] 
+        },
+        type: Executable,
+        machine: EM_ARM,
+        version: 1,
+        entry: 32768,
+        phoff: 52,
+        shoff: 4572,
+        flags: 83886592,
+        ehsize: 52,
+        phentsize: 32,
+        phnum: 1,
+        shentsize: 40,
+        shnum: 8,
+        shstrndx: 7 
+    },
+    pheaders: [
+        Pheader { 
+            type: LOAD,
+            offset: 4096,
+            vaddr: 32768,
+            paddr: 32768,
+            filesz: 12,
+            memsz: 12,
+            flags: Flags(5),
+            align: 4096
+        }
+    ]
+}
+```
+
+Or in the debug output of stinkarm:
+
+```text
+[     0.613ms] opening binary "examples/asm.elf"
+[     0.721ms] parsing ELF...
+[     0.744ms] \
+ELF Header:
+  Magic:              [7f, 45, 4c, 46]
+  Class:              ELF32
+  Data:               Little endian
+  Type:               Executable
+  Machine:            EM_ARM
+  Version:            1
+  Entry point:        0x8000
+  Program hdr offset: 52 (32 bytes each)
+  Section hdr offset: 4572
+  Flags:              0x05000200
+  EH size:            52
+  # Program headers:  1
+  # Section headers:  8
+  Str tbl index:      7
+
+Program Headers:
+  Type       Offset   VirtAddr   PhysAddr   FileSz    MemSz  Flags  Align
+  LOAD     0x001000 0x00008000 0x00008000 0x00000c 0x00000c    R|X 0x1000
+```
+
 # Dumping ELF segments into memory
+
+Before putting each segment into its `Pheader::vaddr`, we have to understand,
+that one doesn't simply `mmap` with `MAP_FIXED` or `MAP_NOREPLACE` into the
+virtual address `0x8000`. The linux kernel won't let us, and rightfully so,
+`man mmap` says:
+
+> If addr is not NULL, then the kernel takes it as a hint about where to place
+> the mapping;  on Linux,  the kernel will pick a nearby page boundary (but
+> always above or equal to the value specified by /proc/sys/vm/mmap_min_addr) and
+> attempt  to  create  the  mapping there.
+
+And `/proc/sys/vm/mmap_min_addr` on my system is `u16::MAX` (2^16)-1=65535. So
+mapping our segment to `0x8000` (32768) is not allowed:
+
+```rust
+let segment = sys::mmap::mmap(
+    // this is only UB if dereferenced, its just a hint, so its safe here
+    Some(unsafe { std::ptr::NonNull::new_unchecked(0x8000 as *mut u8) }),
+    4096,
+    sys::mmap::MmapProt::WRITE,
+    sys::mmap::MmapFlags::ANONYMOUS
+        | sys::mmap::MmapFlags::PRIVATE
+        | sys::mmap::MmapFlags::NOREPLACE,
+    -1,
+    0,
+)
+.unwrap();
+```
+
+Running the above with our `vaddr` of `0x8000` results in:
+
+```text
+thread 'main' panicked at src/main.rs:33:6:
+called `Result::unwrap()` on an `Err` value: "mmap failed (errno 1): Operation not permitted
+(os error 1)"
+```
+
+It only works in elevated permission mode, which is something I dont want to
+run my emulator in.
+
+## Translating guest memory access to host memory access
+
+The obvious fix is to not mmap below `u16::MAX` and let the kernel choose where
+we dump our segment:
+
+```rust
+let segment = sys::mmap::mmap(
+    None,
+    4096,
+    MmapProt::WRITE,
+    MmapFlags::ANONYMOUS | MmapFlags::PRIVATE,
+    -1,
+    0,
+).unwrap();
+```
+
+But this means the segment of the process to emulate is not at `0x8000`, but
+anywhere the kernel allows.
+
+Fixing this with a translation unit has the added benfit of allowing us to
+sandbox guest memory fully, so we can validate each memory access before we
+allow a guest to host memory interaction.
 
 # Decoding armv7
 

--- a/themes/cybernacly/assets/css/main.css
+++ b/themes/cybernacly/assets/css/main.css
@@ -1,490 +1,542 @@
 :root {
-  --spacing: 1rem;
-  --background: #07080d;
-  --background-darker: #0c0709;
-  --background-lighter: #1a1e30;
-  --background-even-lighter: #282e49;
-  --primary: #7fcfff;
-  --primary-darker: #6BB2DB;
-  --primary-dark: #325566;
-  --secondary: #B5D7FF;
-  --secondary-transparent: #B5D7FF10;
-  --text: #cbcbcb;
-  --text-secondary: #919191;
-  --warning: #e0de71;
-  --warning-dark: #3e3d1a;
-  --info: #027aff;
-  --info-dark: #00102e;
-  --tip: #53dfdd;
-  --tip-dark: #082726;
+    --spacing: 1rem;
+    --background: #07080d;
+    --background-darker: #0c0709;
+    --background-lighter: #1a1e30;
+    --background-even-lighter: #282e49;
+    --primary: #7fcfff;
+    --primary-darker: #6BB2DB;
+    --primary-dark: #325566;
+    --secondary: #B5D7FF;
+    --secondary-transparent: #B5D7FF10;
+    --text: #cbcbcb;
+    --text-secondary: #919191;
+    --warning: #e0de71;
+    --warning-dark: #3e3d1a;
+    --info: #027aff;
+    --info-dark: #00102e;
+    --tip: #53dfdd;
+    --tip-dark: #082726;
 }
 
 * {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 /* jetbrains-mono-regular - latin */
 @font-face {
-  font-family: "JetBrains Mono";
-  font-style: normal;
-  font-weight: 400;
-  src:
-    local(""),
-    url("/fonts/jetbrains-mono-v13-latin-regular.woff2") format("woff2"),
-    /* Chrome 26+, Opera 23+, Firefox 39+ */
-      url("/fonts/jetbrains-mono-v13-latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+    font-family: "JetBrains Mono";
+    font-style: normal;
+    font-weight: 400;
+    src:
+        local(""),
+        url("/fonts/jetbrains-mono-v13-latin-regular.woff2") format("woff2"),
+        /* Chrome 26+, Opera 23+, Firefox 39+ */
+        url("/fonts/jetbrains-mono-v13-latin-regular.woff") format("woff");
+    /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* jetbrains-mono-italic - latin */
 @font-face {
-  font-family: "JetBrains Mono";
-  font-style: italic;
-  font-weight: 400;
-  src:
-    local(""),
-    url("/fonts/jetbrains-mono-v13-latin-italic.woff2") format("woff2"),
-    /* Chrome 26+, Opera 23+, Firefox 39+ */
-      url("/fonts/jetbrains-mono-v13-latin-italic.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+    font-family: "JetBrains Mono";
+    font-style: italic;
+    font-weight: 400;
+    src:
+        local(""),
+        url("/fonts/jetbrains-mono-v13-latin-italic.woff2") format("woff2"),
+        /* Chrome 26+, Opera 23+, Firefox 39+ */
+        url("/fonts/jetbrains-mono-v13-latin-italic.woff") format("woff");
+    /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* this should fix the ios mobile code blog font size bug
  * recorded here: https://github.com/adityatelange/hugo-PaperMod/issues/828 */
 code {
-  text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    -moz-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
 }
 
 body {
-  color: var(--text);
-  font-family: "JetBrains Mono", monospace;
-  background-image:
-    radial-gradient(var(--secondary-transparent) 20%, transparent 20%),
-    radial-gradient(var(--secondary-transparent) 20%, transparent 20%);
-  background-position:
-    0 0,
-    50px 50px;
-  background-size: 10px 14px;
-  background-color: var(--background);
-  font-size: 11pt;
+    color: var(--text);
+    font-family: "JetBrains Mono", monospace;
+    background-image:
+        radial-gradient(var(--secondary-transparent) 20%, transparent 20%),
+        radial-gradient(var(--secondary-transparent) 20%, transparent 20%);
+    background-position:
+        0 0,
+        50px 50px;
+    background-size: 10px 14px;
+    background-color: var(--background);
+    font-size: 11pt;
 }
 
 main {
-  width: 100%;
-  margin: 0 auto;
+    width: 100%;
+    margin: 0 auto;
 }
 
 .centered {
-  margin: 0 auto;
-  max-width: 40vw;
+    margin: 0 auto;
+    max-width: 40vw;
 }
 
 nav:not(#TableOfContents) {
-  ul {
-    all: unset;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    list-style: none;
-    margin-top: var(--spacing);
-    margin-bottom: var(--spacing);
+    ul {
+        all: unset;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        list-style: none;
+        margin-top: var(--spacing);
+        margin-bottom: var(--spacing);
 
-    li:first-child {
-      border-left: 1px solid var(--primary);
+        li:first-child {
+            border-left: 1px solid var(--primary);
+        }
+
+        li {
+            background-color: var(--background);
+            position: relative;
+            border: 1px solid var(--primary);
+            border-left: 0;
+            cursor: pointer;
+
+            a {
+                display: block;
+                padding: calc(var(--spacing) / 2);
+                padding-left: calc(var(--spacing) * 1.5);
+                padding-right: calc(var(--spacing) * 1.5);
+            }
+        }
+
+        li:hover {
+            background-color: var(--primary-dark);
+            color: var(--primary-dark);
+        }
     }
-
-    li {
-      background-color: var(--background);
-      position: relative;
-      border: 1px solid var(--primary);
-      border-left: 0;
-      cursor: pointer;
-
-      a {
-        display: block;
-        padding: calc(var(--spacing) / 2);
-        padding-left: calc(var(--spacing) * 1.5);
-        padding-right: calc(var(--spacing) * 1.5);
-      }
-    }
-
-    li:hover {
-      background-color: var(--primary-dark);
-      color: var(--primary-dark);
-    }
-  }
 }
 
 .bio-container {
-  display: flex;
-  justify-content: center;
-  width: 100%;
-
-  .bio {
-    position: relative;
-    background-color: var(--primary-dark);
     display: flex;
-    border: 1px solid var(--primary);
-    padding-right: var(--spacing);
+    justify-content: center;
+    width: 100%;
 
-    img.avatar {
-      margin-right: var(--spacing);
-      height: 10rem;
+    .bio {
+        position: relative;
+        background-color: var(--primary-dark);
+        display: flex;
+        border: 1px solid var(--primary);
+        padding-right: var(--spacing);
+
+        img.avatar {
+            margin-right: var(--spacing);
+            height: 10rem;
+        }
+
+        .content {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+
+            h5 {
+                color: var(--text-secondary);
+            }
+        }
     }
-
-    .content {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-
-      h5 {
-        color: var(--text-secondary);
-      }
-    }
-  }
 }
 
 .pagination {
-  margin-top: calc(var(--spacing) * 2);
-  height: calc(var(--spacing) * 2);
+    margin-top: calc(var(--spacing) * 2);
+    height: calc(var(--spacing) * 2);
 
-  a {
-    padding: calc(var(--spacing) / 2);
-    border: 1px solid var(--primary);
-  }
+    a {
+        padding: calc(var(--spacing) / 2);
+        border: 1px solid var(--primary);
+    }
 
-  a.older {
-    float: right;
-  }
+    a.older {
+        float: right;
+    }
 }
 
 .home {
-  .article .heading {
-    margin-top: calc(var(--spacing) * 2);
-    margin-bottom: calc(var(--spacing) / 2);
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
+    .article .heading {
+        margin-top: calc(var(--spacing) * 2);
+        margin-bottom: calc(var(--spacing) / 2);
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
 
-    h3 {
-      margin: 0;
-    }
+        h3 {
+            margin: 0;
+        }
 
-    h3.draft a {
-      color: var(--primary-darker);
-    }
+        h3.draft a {
+            color: var(--primary-darker);
+        }
 
-    time {
-      min-width: fit-content;
-      color: var(--text-secondary);
+        time {
+            min-width: fit-content;
+            color: var(--text-secondary);
+        }
     }
-  }
 }
 
 .list {
-  .post-archive {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-top: var(--spacing);
-    margin-bottom: var(--spacing);
+    .post-archive {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-top: var(--spacing);
+        margin-bottom: var(--spacing);
 
-    .left {
-      display: flex;
-      align-items: flex-start;
-      margin-right: calc(var(--spacing) / 2);
-    }
+        .left {
+            display: flex;
+            align-items: flex-start;
+            margin-right: calc(var(--spacing) / 2);
+        }
 
-    time {
-      color: var(--text-secondary);
-      min-width: calc(var(--spacing) * 3.5);
-    }
+        time {
+            color: var(--text-secondary);
+            min-width: calc(var(--spacing) * 3.5);
+        }
 
-    h4 {
-      margin: 0;
-      margin-left: var(--spacing);
-    }
+        h4 {
+            margin: 0;
+            margin-left: var(--spacing);
+        }
 
-    .tags {
-      min-width: fit-content;
-    }
+        .tags {
+            min-width: fit-content;
+        }
 
-    .tags a {
-      color: var(--text-secondary);
-      padding: calc(var(--spacing) / 4);
-      text-decoration: none;
+        .tags a {
+            color: var(--text-secondary);
+            padding: calc(var(--spacing) / 4);
+            text-decoration: none;
+        }
     }
-  }
 }
 
 .about {
-  .paper {
-    border: 2px solid var(--primary);
-    border-left: 7px solid var(--primary);
-    margin-top: var(--spacing);
-    padding: var(--spacing);
-    padding-top: 0;
+    .paper {
+        border: 2px solid var(--primary);
+        border-left: 7px solid var(--primary);
+        margin-top: var(--spacing);
+        padding: var(--spacing);
+        padding-top: 0;
 
-    .description::before {
-      content: "> ";
-      color: var(--text-secondary);
-    }
-  }
-
-  .projects {
-    border-spacing: var(--spacing);
-
-    th {
-      text-align: left;
+        .description::before {
+            content: "> ";
+            color: var(--text-secondary);
+        }
     }
 
-    .name {
-      padding: calc(var(--spacing));
-      background-color: var(--primary-dark);
-      border: 2px solid var(--primary);
-      border-left: 7px solid var(--primary);
-    }
+    .projects {
+        border-spacing: var(--spacing);
 
-    td {
-      color: var(--text);
+        th {
+            text-align: left;
+        }
+
+        .name {
+            padding: calc(var(--spacing));
+            background-color: var(--primary-dark);
+            border: 2px solid var(--primary);
+            border-left: 7px solid var(--primary);
+        }
+
+        td {
+            color: var(--text);
+        }
     }
-  }
 }
 
 .post {
-  /* styling for the date, wordcount and read time*/
-  > ul {
-    list-style: none;
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-  }
 
-  > h1 {
-    text-align: center;
-  }
-
-  hr {
-    color: var(--background-lighter);
-  }
-
-  /* markdown output specific styling */
-  .content {
-    img {
-      display: block;
-      max-width: 100%;
+    /* styling for the date, wordcount and read time*/
+    >ul {
+        list-style: none;
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
     }
 
-    .codeblock {
-      max-width: fit-content;
-      padding: calc(var(--spacing) / 4);
-      margin-top: calc(var(--spacing) / 4);
+    >h1 {
+        text-align: center;
     }
 
-    .codeblock,
-    code,
-    pre {
-      background-color: var(--background-lighter);
+    hr {
+        color: var(--background-lighter);
     }
 
-    pre {
-      margin: 0;
-      padding-top: calc(var(--spacing) / 4);
-      padding-bottom: calc(var(--spacing) / 4);
+    /* markdown output specific styling */
+    .content {
+        img {
+            display: block;
+            max-width: 100%;
+        }
+
+        .codeblock {
+            max-width: fit-content;
+            padding: calc(var(--spacing) / 4);
+            margin-top: calc(var(--spacing) / 4);
+        }
+
+        .codeblock,
+        code,
+        pre {
+            background-color: var(--background-lighter);
+        }
+
+        pre {
+            margin: 0;
+            padding-top: calc(var(--spacing) / 4);
+            padding-bottom: calc(var(--spacing) / 4);
+        }
+
+        .highlight {
+            padding-left: calc(var(--spacing) / 4);
+            padding-right: calc(var(--spacing) / 4);
+            background-color: var(--background-lighter);
+            overflow-x: auto;
+
+            /* overwrite all elements with custom background colors to match the theming */
+            * {
+                background-color: var(--background-lighter) !important;
+            }
+
+            /* highlighting lines */
+            span[style*="background-color"] {
+                background-color: var(--background-even-lighter) !important;
+            }
+
+            span[style*="background-color"] span {
+                background-color: var(--background-even-lighter) !important;
+            }
+        }
+
+        #callout,
+        blockquote {
+            margin: 0;
+            margin-top: var(--spacing);
+            margin-bottom: var(--spacing);
+            padding: var(--spacing);
+            padding-top: calc(var(--spacing) / 2);
+            background-color: var(--background);
+            border: 2px solid var(--text-secondary);
+            border-left: 7px solid var(--text-secondary);
+        }
+
+        blockquote {
+            padding-top: var(--spacing);
+        }
+
+        #callout.Tip {
+            background-color: var(--tip-dark);
+            border-color: var(--tip);
+
+            h1,
+            h2,
+            h3,
+            h4 {
+                color: var(--tip);
+            }
+        }
+
+        #callout.Warning {
+            background-color: var(--warning-dark);
+            border-color: var(--warning);
+
+            h1,
+            h2,
+            h3,
+            h4 {
+                color: var(--warning);
+            }
+        }
+
+        #callout.Danger {
+            background-color: var(--primary-dark);
+            border-color: var(--primary);
+
+            h1,
+            h2,
+            h3,
+            h4 {
+                color: var(--primary);
+            }
+        }
+
+        #callout.Info {
+            background-color: var(--info-dark);
+            border-color: var(--info);
+
+            h1,
+            h2,
+            h3,
+            h4 {
+                color: var(--info);
+            }
+        }
+
+        table {
+            margin-top: var(--spacing);
+            margin-bottom: var(--spacing);
+            border-collapse: collapse;
+
+            tbody tr:nth-child(even) {
+                background-color: var(--background-darker);
+            }
+
+            tbody tr:nth-child(odd) {
+                background-color: var(--background-lighter);
+            }
+
+            td,
+            th {
+                padding: calc(var(--spacing) / 2);
+                border: 1px solid var(--text-secondary);
+            }
+        }
     }
-
-    .highlight {
-      padding-left: calc(var(--spacing) / 4);
-      padding-right: calc(var(--spacing) / 4);
-      background-color: var(--background-lighter);
-      overflow-x: auto;
-
-      /* overwrite all elements with custom background colors to match the theming */
-      * {
-        background-color: var(--background-lighter) !important;
-      }
-
-      /* highlighting lines */
-      span[style*="background-color"] {
-        background-color: var(--background-even-lighter) !important;
-      }
-      span[style*="background-color"] span {
-        background-color: var(--background-even-lighter) !important;
-      }
-    }
-
-    #callout,
-    blockquote {
-      margin: 0;
-      margin-top: var(--spacing);
-      margin-bottom: var(--spacing);
-      padding: var(--spacing);
-      padding-top: calc(var(--spacing) / 2);
-      background-color: var(--background);
-      border: 2px solid var(--text-secondary);
-      border-left: 7px solid var(--text-secondary);
-    }
-
-    blockquote {
-      padding-top: var(--spacing);
-    }
-
-    #callout.Tip {
-      background-color: var(--tip-dark);
-      border-color: var(--tip);
-
-      h1,
-      h2,
-      h3,
-      h4 {
-        color: var(--tip);
-      }
-    }
-
-    #callout.Warning {
-      background-color: var(--warning-dark);
-      border-color: var(--warning);
-
-      h1,
-      h2,
-      h3,
-      h4 {
-        color: var(--warning);
-      }
-    }
-
-    #callout.Danger {
-      background-color: var(--primary-dark);
-      border-color: var(--primary);
-
-      h1,
-      h2,
-      h3,
-      h4 {
-        color: var(--primary);
-      }
-    }
-
-    #callout.Info {
-      background-color: var(--info-dark);
-      border-color: var(--info);
-
-      h1,
-      h2,
-      h3,
-      h4 {
-        color: var(--info);
-      }
-    }
-
-    table {
-      margin-top: var(--spacing);
-      margin-bottom: var(--spacing);
-      border-collapse: collapse;
-
-      tbody tr:nth-child(even) {
-        background-color: var(--background-darker);
-      }
-
-      tbody tr:nth-child(odd) {
-        background-color: var(--background-lighter);
-      }
-
-      td,
-      th {
-        padding: calc(var(--spacing) / 2);
-        border: 1px solid var(--text-secondary);
-      }
-    }
-  }
 }
 
 /* overwrites */
 
 a {
-  all: unset;
-  color: var(--primary);
-  cursor: pointer;
-  text-decoration: underline;
+    all: unset;
+    color: var(--primary);
+    cursor: pointer;
+    text-decoration: underline;
 }
 
 a:hover {
-  color: var(--primary-darker);
+    color: var(--primary-darker);
 }
 
 h1 a,
 h2 a,
 h3 a,
 h4 a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 h1,
 h2,
 h3,
 h4 {
-  color: var(--secondary);
+    color: var(--secondary);
 }
 
 footer {
-  text-align: center;
+    text-align: center;
 }
 
 code {
-  font-family: "JetBrains Mono", monospace;
+    font-family: "JetBrains Mono", monospace;
+}
+
+summary {
+    list-style: none;
+    color: var(--info);
+
+    h3 {
+        user-select: none;
+        color: var(--info);
+    }
+}
+
+summary::-webkit-details-marker {
+    display: none;
+    /* Chrome/Safari */
+}
+
+summary {
+    cursor: pointer;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    padding: calc(var(--spacing)/2);
+}
+
+details {
+    margin: 0;
+    margin-top: var(--spacing);
+    margin-bottom: var(--spacing);
+    padding: calc(var(--spacing)/2);
+    border: 2px solid var(--text-secondary);
+    border-left: 7px solid var(--text-secondary);
+    background-color: var(--info-dark);
+    border-color: var(--info);
+
+}
+
+summary::before {
+    content: ">>>";
+    margin-right: var(--spacing);
+    display: inline-block;
+}
+
+details[open] summary::before {
+    content: "vvv";
 }
 
 @media only screen and (max-width: 600px) {
-  .list {
-    .post-archive {
-      flex-direction: column;
-      .left {
-        flex-direction: column;
-        align-items: flex-start;
-        justify-content: start;
-        h4 {
-          margin-left: 0;
+    .list {
+        .post-archive {
+            flex-direction: column;
+
+            .left {
+                flex-direction: column;
+                align-items: flex-start;
+                justify-content: start;
+
+                h4 {
+                    margin-left: 0;
+                }
+            }
+
+            .tags a {
+                padding-left: 0;
+            }
         }
-      }
-      .tags a {
-        padding-left: 0;
-      }
     }
-  }
 }
 
 @media only screen and (max-width: 1600px) {
-  .centered {
-    max-width: 90vw;
-  }
+    .centered {
+        max-width: 90vw;
+    }
 }
 
 .emoji {
-  position: fixed;
-  top: -50px;
-  pointer-events: none;
-  user-select: none;
-  font-size: 2rem;
-  z-index: 9999;
+    position: fixed;
+    top: -50px;
+    pointer-events: none;
+    user-select: none;
+    font-size: 2rem;
+    z-index: 9999;
 
-  animation-name: fallFade;
-  animation-timing-function: linear;
-  animation-fill-mode: forwards;
+    animation-name: fallFade;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
 }
 
 @keyframes fallFade {
-  0% {
-    transform: translateY(0) rotate(0deg);
-    opacity: 1;
-  }
-  80% {
-    opacity: 1;
-  }
-  100% {
-    transform: translateY(100vh) rotate(360deg);
-    opacity: 0;
-  }
+    0% {
+        transform: translateY(0) rotate(0deg);
+        opacity: 1;
+    }
+
+    80% {
+        opacity: 1;
+    }
+
+    100% {
+        transform: translateY(100vh) rotate(360deg);
+        opacity: 0;
+    }
 }


### PR DESCRIPTION
```yml
title: "Building a Minimal Viable Armv7 Emulator from Scratch"
date: 2025-11-19
summary: "Emulating armv7 is surprisingly easy, even from scratch AND in Rust"
tags:
  - arm
  - rust
```

## TLDR:

> I wrote a minimal viable armv7 emulator in 1.3k lines of Rust without any dependencies. It parses and validates a 32-bit arm binary, maps its segments, decodes a subset of arm instructions, translates guest and host memory interactions and forwards arm Linux syscalls into x86-64 System V syscalls.
> 
> It can run a armv7 hello world binary and does so in 0.150ms (with parsing). 